### PR TITLE
Fix #21

### DIFF
--- a/attrib/attrib.go
+++ b/attrib/attrib.go
@@ -19,6 +19,7 @@
 // used to access Manatee C library.
 package attrib
 
+// #cgo CXXFLAGS: -std=c++11
 // #cgo CFLAGS: -I${SRCDIR}/attrib -I${SRCDIR}/attrib/corp
 // #cgo LDFLAGS:  -lmanatee -L${SRCDIR} -Wl,-rpath='$ORIGIN'
 // #include <stdlib.h>

--- a/build
+++ b/build
@@ -99,6 +99,12 @@ def unpack_archive(path):
     p.wait()
     return p.returncode
 
+def init_sources(manatee_src, finlib_src):
+    if finlib_src is not None:
+        subprocess.Popen('make clean', shell=True, cwd=finlib_src, executable='/bin/bash').wait()
+        subprocess.Popen('./configure --with-pcre', shell=True, cwd=finlib_src, executable='/bin/bash').wait()
+    subprocess.Popen('make clean', shell=True, cwd=manatee_src, executable='/bin/bash').wait()
+    subprocess.Popen('./configure --with-pcre', shell=True, cwd=manatee_src, executable='/bin/bash').wait()
 
 def build_project(manatee_src, finlib_src, manatee_lib):
     if finlib_src:
@@ -198,6 +204,7 @@ if __name__ == '__main__':
     except:
         pass
 
+    init_sources(manatee_src, finlib_src)
     build_project(manatee_src, finlib_src, manatee_lib)
 
     if should_generate_run_script:


### PR DESCRIPTION
The commit solves the problem between Manatee 2.158.8 and older
versions of gcc (uint32_t type). Now we force C++11 standard
in cgo configuration in attrib.go