### PR TITLE
Improve fixgaps, simplify controls

### DIFF
--- a/calign/calign.go
+++ b/calign/calign.go
@@ -49,18 +49,17 @@ type AttribMapper interface {
 // Processor represents an object used
 // to process an alignment XML input file.
 type Processor struct {
-	attr1           AttribMapper
-	attr2           AttribMapper
-	valPrefix       string
-	valSuffix       string
-	valOffset       int
-	lastPos         int
-	lastPivotPos    int
-	pivotStructSize int
+	attr1        AttribMapper
+	attr2        AttribMapper
+	valPrefix    string
+	valSuffix    string
+	valOffset    int
+	lastPos      int
+	lastPivotPos int
 }
 
 // NewProcessor creates a new instance of Processor
-func NewProcessor(attr1 AttribMapper, attr2 AttribMapper, pivotSize int, quoteStyle int) *Processor {
+func NewProcessor(attr1 AttribMapper, attr2 AttribMapper, quoteStyle int) *Processor {
 	valPrefix := "xtargets='"
 	valSuffix := "'"
 	if quoteStyle == quoteStyleDouble {
@@ -69,14 +68,13 @@ func NewProcessor(attr1 AttribMapper, attr2 AttribMapper, pivotSize int, quoteSt
 	}
 
 	return &Processor{
-		attr1:           attr1,
-		attr2:           attr2,
-		valPrefix:       valPrefix,
-		valSuffix:       valSuffix,
-		valOffset:       len(valPrefix),
-		lastPos:         0,
-		lastPivotPos:    0,
-		pivotStructSize: pivotSize,
+		attr1:        attr1,
+		attr2:        attr2,
+		valPrefix:    valPrefix,
+		valSuffix:    valSuffix,
+		valOffset:    len(valPrefix),
+		lastPos:      0,
+		lastPivotPos: 0,
 	}
 }
 
@@ -181,17 +179,6 @@ func (p *Processor) ProcessFile(file *os.File, bufferSize int, onItem func(item 
 				log.Printf("ERROR: %s (file: %s)", err, filepath.Base(file.Name()))
 			}
 		}
-	}
-	if p.lastPos < p.pivotStructSize-1 {
-		onItem(mapping.Mapping{
-			From: mapping.NewEmptyPosRange(),
-			To: mapping.PosRange{
-				First: p.lastPivotPos + 1,
-				Last:  p.pivotStructSize - 1,
-			},
-			IsGap: true,
-		}, count)
-		count++
 	}
 	err := reader.Err()
 	if err != nil {

--- a/calign/calign_test.go
+++ b/calign/calign_test.go
@@ -74,9 +74,8 @@ func (ma *MockAttr2) Str2ID(value string) int {
 
 func createProcessor() *Processor {
 	return &Processor{
-		attr1:           &MockAttr1{},
-		attr2:           &MockAttr2{},
-		pivotStructSize: 2,
+		attr1: &MockAttr1{},
+		attr2: &MockAttr2{},
 	}
 }
 
@@ -245,13 +244,12 @@ func TestProcessLineRangeMissing2(t *testing.T) {
 func TestNewProcessor(t *testing.T) {
 	attr1 := &MockAttr1{}
 	attr2 := &MockAttr2{}
-	p := NewProcessor(attr1, attr2, 10, quoteStyleSingle)
+	p := NewProcessor(attr1, attr2, quoteStyleSingle)
 	assert.Equal(t, p.valPrefix, "xtargets='")
 	assert.Equal(t, p.valSuffix, "'")
 	assert.Equal(t, p.valOffset, len("xtargets='"))
 	assert.Equal(t, p.lastPos, 0)
 	assert.Equal(t, p.lastPivotPos, 0)
-	assert.Equal(t, p.pivotStructSize, 10)
 	assert.Equal(t, p.attr1, attr1)
 	assert.Equal(t, p.attr2, attr2)
 }
@@ -259,13 +257,12 @@ func TestNewProcessor(t *testing.T) {
 func TestNewProcessorDoubleQ(t *testing.T) {
 	attr1 := &MockAttr1{}
 	attr2 := &MockAttr2{}
-	p := NewProcessor(attr1, attr2, 10, quoteStyleDouble)
+	p := NewProcessor(attr1, attr2, quoteStyleDouble)
 	assert.Equal(t, p.valPrefix, "xtargets=\"")
 	assert.Equal(t, p.valSuffix, "\"")
 	assert.Equal(t, p.valOffset, len("xtargets=\""))
 	assert.Equal(t, p.lastPos, 0)
 	assert.Equal(t, p.lastPivotPos, 0)
-	assert.Equal(t, p.pivotStructSize, 10)
 	assert.Equal(t, p.attr1, attr1)
 	assert.Equal(t, p.attr2, attr2)
 }
@@ -290,7 +287,6 @@ func TestProcessFile(t *testing.T) {
 		panic(err)
 	}
 	p := createFullProcessor()
-	p.pivotStructSize = 10
 	i2 := 0 // we deliberately ignore argument 'i' as possibly flawed
 	err = p.ProcessFile(f, 1000, func(item mapping.Mapping, i int) {
 		assert.Equal(t, valData[i2], item)


### PR DESCRIPTION
Filling-in missing ends of data lists is now
implemented for both languages (left and pivot) and
the whole functionality is now part of "fixgaps"
(where it belongs).